### PR TITLE
[UI] 개별 스터디방의 개별 문제 페이지 UI 구현 (#17)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.5.0",
         "react": "^18.2.0",
+        "react-copy-to-clipboard": "^5.1.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.16.0",
         "react-scripts": "5.0.1",
@@ -6346,6 +6347,14 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
     },
     "node_modules/core-js": {
       "version": "3.32.2",
@@ -14728,6 +14737,18 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
+    "node_modules/react-copy-to-clipboard": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz",
+      "integrity": "sha512-k61RsNgAayIJNoy9yDsYzDe/yAZAzEbEgcz3DZMhF686LEyukcE1hzurxe85JandPUG+yTfGVFzuEw3xt8WP/A==",
+      "dependencies": {
+        "copy-to-clipboard": "^3.3.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || 16 || 17 || 18"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -16693,6 +16714,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.5.0",
     "react": "^18.2.0",
+    "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",

--- a/src/components/studyroomWork/PlusModal.jsx
+++ b/src/components/studyroomWork/PlusModal.jsx
@@ -1,0 +1,90 @@
+import PlusBtn from "../../assets/Btn_plus.png";
+import styled from "styled-components";
+import useModal from "../../hooks/useModal";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function PlusModal() {
+  const { openModal, Modal } = useModal();
+  const navigate = useNavigate();
+
+  // 모달 내용 변경하기 (추가 클릭 시 추가되었다는 내용으로 변경)
+  const [modalContent, setModalContent] = useState("confirm");
+
+  // 모달 내용 변경 함수
+  const handleChangeContent = () => {
+    if (modalContent === "confirm") {
+      setModalContent("other");
+    } else {
+      //나의 문제집으로 이동할 url로 수정 예정
+      navigate("/");
+    }
+  };
+
+  // open modal
+  const handleModal = () => {
+    openModal();
+  };
+
+  return (
+    <>
+      <Img src={PlusBtn} alt="plus" onClick={handleModal} />
+
+      {/* modal */}
+      <Modal style={{ width: "400px", height: "220px" }}>
+        <ModalContent>
+          <div>
+            {/* 모달 내용 상태에 따라 다른 컨텐츠 렌더링 */}
+            {modalContent === "confirm" ? (
+              <>
+                <ModalBody>나의 문제집에 추가하시겠습니까?</ModalBody>
+                <Button onClick={handleChangeContent}>추가하기</Button>
+              </>
+            ) : (
+              <>
+                <ModalBody>나의 문제집에 추가되었습니다. </ModalBody>
+                <Button onClick={handleChangeContent}>
+                  나의 문제집으로 이동하기
+                </Button>
+              </>
+            )}
+          </div>
+          {/* <Button>추가하기</Button> */}
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}
+
+const Img = styled.img`
+  margin-right: 10px;
+`;
+
+const ModalContent = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  margin-top: 60px;
+  font-size: 14px;
+  text-align: center;
+`;
+
+const ModalBody = styled.div`
+  margin-bottom: 20px;
+  color: #c7c7c7;
+  text-align: center;
+  margin-bottom: 30px;
+`;
+
+const Button = styled.button`
+  width: 301px;
+  height: 37px;
+  background-color: #5263ff;
+  font-size: 14px;
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  margin-top: 20px;
+`;

--- a/src/components/studyroomWork/RecommendItem.jsx
+++ b/src/components/studyroomWork/RecommendItem.jsx
@@ -1,0 +1,91 @@
+import styled from "styled-components";
+import UserIcon from "../../assets/people.png";
+import HeartIcon from "../../assets/heart.png";
+import ChatIcon from "../../assets/chat.png";
+import { useNavigate } from "react-router-dom";
+
+export default function RecommendItem() {
+  const navigate = useNavigate();
+  return (
+    <Wrapper onClick={() => navigate("/study/:studyroomid")}>
+      <Container>
+        <UserInfo>
+          <UserImage src={UserIcon} alt="user" />
+          <UserName>소밍밍</UserName>
+        </UserInfo>
+        <UserStats>
+          <Stat>
+            <UserImage src={HeartIcon} alt="heart" />
+            26
+          </Stat>
+          <Stat>
+            <UserImage src={ChatIcon} alt="chat" />
+            04
+          </Stat>
+        </UserStats>
+      </Container>
+      <ItemInfo>
+        <ItemText>정보처리기사 실기_2023</ItemText>
+        <ItemStat>91문제</ItemStat>
+      </ItemInfo>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  width: 482px;
+  height: 106px;
+  background-color: #24252b;
+  border: 1px solid #555555;
+  border-radius: 6px;
+  margin-bottom: 20px;
+  padding: 20px;
+`;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const UserInfo = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const UserImage = styled.img`
+  margin-right: 7px;
+`;
+
+const UserName = styled.div`
+  magin-right: 10px;
+  font-size: 16px;
+`;
+
+const UserStats = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const Stat = styled.div`
+  display: flex;
+  align-items: center;
+  margin-right: 10px;
+  font-size: 16px;
+`;
+
+const ItemInfo = styled.div`
+  display: flex;
+  align-items: center;
+  //justify-content: space-between;
+  margin-top: 25px;
+`;
+
+const ItemText = styled.div`
+  text-align: left;
+  margin-right: 30px;
+`;
+
+const ItemStat = styled.span`
+  text-align: center;
+  margin-left: 10px;
+`;

--- a/src/components/studyroomWork/RecommendItem.jsx
+++ b/src/components/studyroomWork/RecommendItem.jsx
@@ -1,33 +1,26 @@
 import styled from "styled-components";
 import UserIcon from "../../assets/people.png";
-import HeartIcon from "../../assets/heart.png";
-import ChatIcon from "../../assets/chat.png";
-import { useNavigate } from "react-router-dom";
+import GroupIcon from "../../assets/group.png";
+import JoinIcon from "../../assets/Btn_join.png";
 
 export default function RecommendItem() {
-  const navigate = useNavigate();
   return (
-    <Wrapper onClick={() => navigate("/study/:studyroomid")}>
+    <Wrapper>
+      <ItemInfo>스터디방명 이름 예시 SW 삼성 2023 하반기 공채</ItemInfo>
+
       <Container>
         <UserInfo>
-          <UserImage src={UserIcon} alt="user" />
-          <UserName>소밍밍</UserName>
+          <Stat>
+            <UserImage src={UserIcon} alt="user" />
+            <UserName>소밍밍</UserName>
+          </Stat>
+          <Stat>
+            <UserImage src={GroupIcon} alt="group" />
+            21/50
+          </Stat>
         </UserInfo>
-        <UserStats>
-          <Stat>
-            <UserImage src={HeartIcon} alt="heart" />
-            26
-          </Stat>
-          <Stat>
-            <UserImage src={ChatIcon} alt="chat" />
-            04
-          </Stat>
-        </UserStats>
+        <UserImage src={JoinIcon} alt="join" />
       </Container>
-      <ItemInfo>
-        <ItemText>정보처리기사 실기_2023</ItemText>
-        <ItemStat>91문제</ItemStat>
-      </ItemInfo>
     </Wrapper>
   );
 }
@@ -57,35 +50,21 @@ const UserImage = styled.img`
 `;
 
 const UserName = styled.div`
-  magin-right: 10px;
+  magin-right: 20px;
   font-size: 16px;
-`;
-
-const UserStats = styled.div`
-  display: flex;
-  align-items: center;
 `;
 
 const Stat = styled.div`
   display: flex;
   align-items: center;
-  margin-right: 10px;
+  margin-right: 20px;
   font-size: 16px;
 `;
 
 const ItemInfo = styled.div`
   display: flex;
   align-items: center;
-  //justify-content: space-between;
-  margin-top: 25px;
-`;
-
-const ItemText = styled.div`
   text-align: left;
-  margin-right: 30px;
-`;
-
-const ItemStat = styled.span`
-  text-align: center;
-  margin-left: 10px;
+  margin-bottom: 20px;
+  margin-top: 20px;
 `;

--- a/src/components/studyroomWork/RecommendList.jsx
+++ b/src/components/studyroomWork/RecommendList.jsx
@@ -1,0 +1,35 @@
+import styled from "styled-components";
+import RecommendItem from "./RecommendItem";
+
+export default function RecommendList() {
+  const recommdItems = Array(6).fill(null); // 6개 추천 문제집
+  // 추천 기능을 구현 안해서 우선은 6개를 렌더링했음
+
+  return (
+    <Container>
+      <Title>추천 문제집</Title>
+      <ItemBox>
+        {recommdItems.map((_, index) => (
+          <RecommendItem key={index} />
+        ))}
+      </ItemBox>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  margin-top: 30px;
+`;
+
+const Title = styled.div`
+  font-size: 22px;
+  font-weight: 600;
+  margin-bottom: 30px;
+`;
+
+const ItemBox = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-gap: 20px;
+  margin-bottom: 10px;
+`;

--- a/src/components/studyroomWork/RecommendList.jsx
+++ b/src/components/studyroomWork/RecommendList.jsx
@@ -7,7 +7,7 @@ export default function RecommendList() {
 
   return (
     <Container>
-      <Title>추천 문제집</Title>
+      <Title>추천 스터디방</Title>
       <ItemBox>
         {recommdItems.map((_, index) => (
           <RecommendItem key={index} />

--- a/src/components/studyroomWork/ShareModal.jsx
+++ b/src/components/studyroomWork/ShareModal.jsx
@@ -1,0 +1,75 @@
+import ShareBtn from "../../assets/Btn_share.png";
+import styled from "styled-components";
+import useModal from "../../hooks/useModal";
+import { CopyToClipboard } from "react-copy-to-clipboard";
+
+export default function ShareModal() {
+  const { openModal, closeModal, Modal } = useModal();
+
+  // open modal
+  const handleModal = () => {
+    openModal();
+  };
+
+  // window 객체에서 현재 url 가져오기
+  const currentURL = window.location.href;
+
+  // url 복사 후 닫기
+  const handlerButton = () => {
+    alert("복사되었습니다");
+    closeModal();
+  };
+
+  return (
+    <>
+      <Img onClick={handleModal} src={ShareBtn} alt="outstudy" />
+
+      {/* modal */}
+      <Modal style={{ width: "400px", height: "220px" }}>
+        <ModalContent>
+          <div>
+            <ModalBody>
+              문제 공유하기 원하시면 하단의 복사 버튼을 누르세요 !
+            </ModalBody>
+          </div>
+          <CopyToClipboard text={currentURL} onCopy={handlerButton}>
+            <Button>URL 복사</Button>
+          </CopyToClipboard>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}
+
+const Img = styled.img`
+  margin-right: 10px;
+`;
+
+const ModalContent = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  margin-top: 60px;
+  font-size: 14px;
+  text-align: center;
+`;
+
+const ModalBody = styled.div`
+  margin-bottom: 20px;
+  color: #c7c7c7;
+  text-align: center;
+  margin-bottom: 30px;
+`;
+
+const Button = styled.button`
+  width: 301px;
+  height: 37px;
+  background-color: #5263ff;
+  font-size: 14px;
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  margin-top: 20px;
+`;

--- a/src/pages/StudyWork.jsx
+++ b/src/pages/StudyWork.jsx
@@ -16,10 +16,10 @@ const StudyWork = () => {
         <Img src={ShareBtn} alt="share" />
       </Buttons>
       <Answer>A.</Answer>
-      <div>
-        <textarea placeholder="정답을 입력해주세요" type="text-area" />
-        <button>입력</button>
-      </div>
+      <ABox>
+        <ATextArea placeholder="정답을 입력해주세요" type="text-area" />
+        <AButton>제출</AButton>
+      </ABox>
       <div>추천 스터디방</div>
     </Wrapper>
   );
@@ -72,4 +72,43 @@ const Answer = styled.div`
   color: #5263ff;
   font-size: 35px;
   font-weight: 400;
+`;
+
+const ABox = styled.div`
+  width: 1090px;
+  height: 158px;
+  background-color: #3f424e;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  margin-top: 20px;
+`;
+
+const ATextArea = styled.textarea`
+  flex: 1;
+  width: 958px;
+  height: 114px;
+  margin-right: 5px;
+  margin-left: 10px;
+  background-color: #8f8f8f;
+  border: 1px solid #dddddd;
+  border-radius: 6px;
+  padding: 10px;
+
+  &::placeholder {
+    font-size: 15px;
+    padding: 5px;
+    color: #000000;
+  }
+`;
+
+const AButton = styled.button`
+  width: 91px;
+  height: 114px;
+  border: none;
+  border-radius: 6px;
+  background-color: #a7a7a7;
+  font-size: 15px;
+  color: #000000;
+  margin-right: 10px;
 `;

--- a/src/pages/StudyWork.jsx
+++ b/src/pages/StudyWork.jsx
@@ -65,10 +65,6 @@ const Buttons = styled.div`
   text-align: left;
 `;
 
-const Img = styled.img`
-  margin-right: 10px;
-`;
-
 const Answer = styled.div`
   color: #5263ff;
   font-size: 35px;
@@ -88,7 +84,7 @@ const ABox = styled.div`
 const ATextArea = styled.textarea`
   flex: 1;
   width: 958px;
-  height: 114px;
+  height: 95px;
   margin-right: 5px;
   margin-left: 10px;
   background-color: #8f8f8f;

--- a/src/pages/StudyWork.jsx
+++ b/src/pages/StudyWork.jsx
@@ -1,5 +1,53 @@
+import styled from "styled-components";
+import PlusBtn from "../assets/Btn_plus.png";
+import ShareBtn from "../assets/Btn_share.png";
+
 const StudyWork = () => {
-  return <div>스터디방 학습 페이지입니다</div>;
+  return (
+    <Wrapper>
+      <Title>삼성 SW 역량테스트 기출문제 스터디방 {">"} 21번 문제 제목 </Title>
+      <Question>Q.</Question>
+      <div>
+        문제 예시 입력 브라우저에서 렌더 트리를 구축하는 과정은 어떻게 될까요?
+      </div>
+      <div></div>
+      <div>
+        <Answer>A.</Answer>
+        <div>
+          <img src={PlusBtn} alt="plus" />
+          <img src={ShareBtn} alt="share" />
+        </div>
+      </div>
+      <div>
+        <textarea placeholder="정답을 입력해주세요" type="text-area" />
+        <button>입력</button>
+      </div>
+      <div>추천 스터디방</div>
+    </Wrapper>
+  );
 };
 
 export default StudyWork;
+
+const Wrapper = styled.div`
+  max-width: 1090px;
+  margin: 0 auto;
+`;
+
+const Title = styled.div`
+  font-size: 14.5px;
+  color: #c9c9c9;
+  margin-bottom: 30px;
+`;
+
+const Question = styled.div`
+  color: #5263ff;
+  font-size: 35px;
+  font-weight: 400;
+`;
+
+const Answer = styled.div`
+  color: #5263ff;
+  font-size: 35px;
+  font-weight: 400;
+`;

--- a/src/pages/StudyWork.jsx
+++ b/src/pages/StudyWork.jsx
@@ -2,11 +2,19 @@ import styled from "styled-components";
 import RecommendList from "../components/studyroomWork/RecommendList";
 import PlusModal from "../components/studyroomWork/PlusModal";
 import ShareModal from "../components/studyroomWork/ShareModal";
+import { useNavigate } from "react-router-dom";
 
 const StudyWork = () => {
+  const navigate = useNavigate();
+
   return (
     <Wrapper>
-      <Title>삼성 SW 역량테스트 기출문제 스터디방 {">"} 21번 문제 제목 </Title>
+      <Title>
+        <Span onClick={() => navigate("/study/:studyroomid")}>
+          삼성 SW 역량테스트 기출문제 스터디방
+        </Span>{" "}
+        {">"} 21번 문제 제목{" "}
+      </Title>
       <Question>Q.</Question>
       <QContent>
         문제 예시 입력 브라우저에서 렌더 트리를 구축하는 과정은 어떻게 될까요?
@@ -37,6 +45,13 @@ const Title = styled.div`
   font-size: 14.5px;
   color: #c9c9c9;
   margin-bottom: 30px;
+`;
+
+const Span = styled.span`
+  &:hover {
+    text-decoration: underline;
+    color: #ffffff;
+  }
 `;
 
 const Question = styled.div`

--- a/src/pages/StudyWork.jsx
+++ b/src/pages/StudyWork.jsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import PlusBtn from "../assets/Btn_plus.png";
 import ShareBtn from "../assets/Btn_share.png";
+import RecommendList from "../components/studyroomWork/RecommendList";
 
 const StudyWork = () => {
   return (
@@ -20,7 +21,7 @@ const StudyWork = () => {
         <ATextArea placeholder="정답을 입력해주세요" type="text-area" />
         <AButton>제출</AButton>
       </ABox>
-      <div>추천 스터디방</div>
+      <RecommendList />
     </Wrapper>
   );
 };

--- a/src/pages/StudyWork.jsx
+++ b/src/pages/StudyWork.jsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
-import PlusBtn from "../assets/Btn_plus.png";
 import ShareBtn from "../assets/Btn_share.png";
 import RecommendList from "../components/studyroomWork/RecommendList";
+import PlusModal from "../components/studyroomWork/PlusModal";
 
 const StudyWork = () => {
   return (
@@ -13,7 +13,7 @@ const StudyWork = () => {
       </QContent>
       <Line></Line>
       <Buttons>
-        <Img src={PlusBtn} alt="plus" />
+        <PlusModal />
         <Img src={ShareBtn} alt="share" />
       </Buttons>
       <Answer>A.</Answer>

--- a/src/pages/StudyWork.jsx
+++ b/src/pages/StudyWork.jsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
-import ShareBtn from "../assets/Btn_share.png";
 import RecommendList from "../components/studyroomWork/RecommendList";
 import PlusModal from "../components/studyroomWork/PlusModal";
+import ShareModal from "../components/studyroomWork/ShareModal";
 
 const StudyWork = () => {
   return (
@@ -14,7 +14,7 @@ const StudyWork = () => {
       <Line></Line>
       <Buttons>
         <PlusModal />
-        <Img src={ShareBtn} alt="share" />
+        <ShareModal />
       </Buttons>
       <Answer>A.</Answer>
       <ABox>

--- a/src/pages/StudyWork.jsx
+++ b/src/pages/StudyWork.jsx
@@ -7,17 +7,15 @@ const StudyWork = () => {
     <Wrapper>
       <Title>삼성 SW 역량테스트 기출문제 스터디방 {">"} 21번 문제 제목 </Title>
       <Question>Q.</Question>
-      <div>
+      <QContent>
         문제 예시 입력 브라우저에서 렌더 트리를 구축하는 과정은 어떻게 될까요?
-      </div>
-      <div></div>
-      <div>
-        <Answer>A.</Answer>
-        <div>
-          <img src={PlusBtn} alt="plus" />
-          <img src={ShareBtn} alt="share" />
-        </div>
-      </div>
+      </QContent>
+      <Line></Line>
+      <Buttons>
+        <Img src={PlusBtn} alt="plus" />
+        <Img src={ShareBtn} alt="share" />
+      </Buttons>
+      <Answer>A.</Answer>
       <div>
         <textarea placeholder="정답을 입력해주세요" type="text-area" />
         <button>입력</button>
@@ -44,6 +42,30 @@ const Question = styled.div`
   color: #5263ff;
   font-size: 35px;
   font-weight: 400;
+`;
+
+const QContent = styled.div`
+  margin-top: 30px;
+  margin-bottom: 30px;
+  font-size: 17px;
+`;
+
+const Line = styled.div`
+  width: 1090px;
+  border: 1px solid #868686;
+  margin-top: 15px;
+  margin-bottom: 30px;
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  justify-content: right;
+  align-items: left;
+  text-align: left;
+`;
+
+const Img = styled.img`
+  margin-right: 10px;
 `;
 
 const Answer = styled.div`


### PR DESCRIPTION
## PR 타입
UI 구현

## 반영 브랜치
ui/#17 => develop

closed #17

## 변경 사항
![localhost_3000_study__studyroonid_worklistid](https://github.com/QuizUpWebProject/front/assets/95006849/0f873af2-d1e9-4652-b03d-67c41825d81d)
- 스터디방 > 문제 제목 (스터디방 클릭 시 해당 스터디방 메인 페이지로 이동합니다)
- `나의 문제집에 추가` 버튼
   - `추가하기` 버튼 클릭 시 다른 모달로 콘텐츠 변경 (`추가하였습니다`를 안내)
   - '완료' 후 모달이 완전히 닫힙니다
- `공유하기` 버튼
   - 공유하기를 위해 `react-copy-to-clipboard` 라이브러리를 설치했습니다
- 문제
- 답안
   - 답안을 작성할 수 있도록 textarea 구현
   - `등록` 버튼 구현 (링크는 answer 페이지 UI 구현 후 추가할 예정)
- 추천 스터디방
   - 추천 기능 구현 전이라 임시로 `RecommendItem`을 6번 렌더링했습니다
   - '가입하기' 버튼 클릭 시 공개/비공개 에 따라 달라지는 것은 기능 구현 시 함께 구현할 예정입니다 