### PR TITLE
[UI] 프론트 메인 페이지 UI 구현 (#10)

### DIFF
--- a/src/components/front/FrontItem.jsx
+++ b/src/components/front/FrontItem.jsx
@@ -1,0 +1,67 @@
+import styled from "styled-components";
+import { Link } from 'react-router-dom';
+import UserIcon from "../../assets/people.png";
+import LikeIcon from "../../assets/heart.png";
+import CmtIcon from "../../assets/chat.png";
+import StartBtn from "../../assets/Btn_start.png";
+
+function formatNumber(num) {
+  return num < 10 ? `0${num}` : num.toString();
+}
+
+const FrontItem = ({ item, index}) => {
+  return (
+    <Container>
+      <div>{formatNumber(index+1)}</div>
+      <div>{item.title}</div>
+      <div>{item.date}</div>
+      <div>
+        <IconTextWrapper>
+          <Icon src={UserIcon} alt="작성자" />{item.user}
+        </IconTextWrapper>
+      </div>
+      <div>
+        <IconTextWrapper>
+          <Icon src={LikeIcon} alt="추천" />{formatNumber(item.like)}
+        </IconTextWrapper>
+      </div>
+      <div>
+        <IconTextWrapper>
+          <Icon src={CmtIcon} alt="댓글" />{formatNumber(item.cmt)}
+        </IconTextWrapper>
+      </div>
+      <div>
+        <Link to='/front/:worklistid'>
+          <img src={StartBtn} alt="학습하기"/>
+        </Link>
+      </div>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  position: relative;
+  justify-content: space-between;
+  align-items: center;
+  width: 1090px;
+  font-size: 15px;
+  padding: 5px 0;
+  border-bottom: 1px solid #ddd;
+  border-top: 1px solid #ddd;
+
+  &:not(:first-child) {
+    margin-top: -1px; /* 첫 번째 div는 마진을 설정하지 않습니다. */
+  }
+`;
+
+const IconTextWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const Icon = styled.img`
+  padding: 0 5px;
+`;
+
+export default FrontItem;

--- a/src/components/front/FrontList.jsx
+++ b/src/components/front/FrontList.jsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import styled from "styled-components";
+import FrontItem from "./FrontItem";
+import usePagination from "../../hooks/usePagination";
+import LeftIcon from "../../assets/left.png";
+import RightIcon from "../../assets/right.png";
+
+export default function FrontList() {
+  // 임시 프론트 문제집 data 
+  const frontData = [
+    {id: 1, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-10-15", user: "소밍밍", like: 10, cmt: 5},
+    {id: 2, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-10-14", user: "소밍밍", like: 2, cmt: 5},
+    {id: 3, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-10-13", user: "소밍밍", like: 0, cmt: 5},
+    {id: 4, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-10-12", user: "소밍밍", like: 1, cmt: 10},
+    {id: 5, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-10-11", user: "소밍밍", like: 15, cmt: 11},
+    {id: 6, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-10-10", user: "소밍밍", like: 12, cmt: 14},
+    {id: 7, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-10-09", user: "소밍밍", like: 11, cmt: 18},
+    {id: 8, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-10-08", user: "소밍밍", like: 9, cmt: 31},
+    {id: 9, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-10-07", user: "소밍밍", like: 19, cmt: 11},
+    {id: 10, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-10-06", user: "소밍밍", like: 30, cmt: 10},
+    {id: 11, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-10-05", user: "소밍밍", like: 5, cmt: 9},
+    {id: 12, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-10-04", user: "소밍밍", like: 6, cmt: 8},
+    {id: 13, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-10-03", user: "소밍밍", like: 0, cmt: 0},
+    {id: 14, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-10-02", user: "소밍밍", like: 11, cmt: 1},
+    {id: 15, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-10-01", user: "소밍밍", like: 10, cmt: 3},
+    {id: 16, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-09-30", user: "소밍밍", like: 10, cmt: 5},
+    {id: 17, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-09-29", user: "소밍밍", like: 10, cmt: 15},
+    {id: 18, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-09-28", user: "소밍밍", like: 10, cmt: 50},
+    {id: 19, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-09-27", user: "소밍밍", like: 10, cmt: 11},
+  ];
+
+  const [data, setData] = useState(frontData); // 데이터 상태 정의
+
+  const itemsPerPage = 15; // 페이지 당 보여줄 아이템 수
+  const {
+    currentPage,
+    currentItems,
+    totalPages,
+    paginate,
+    goToPrevPage,
+    goToNextPage,
+  } = usePagination(
+    data, // 데이터를 frontData로 변경
+    itemsPerPage
+  );
+
+  return(
+    <div>
+      {/* 필터링된 스터디 리스트 표시 */}
+      <div>
+        {/* 현재 페이지의 아이템 렌더링 */}
+        {currentItems.map((front, index) => (
+          <FrontItem key={front.id} item={front} index={index}/>
+        ))}
+
+        {/* 페이지네이션 컴포넌트 렌더링 */}
+        <PaginationContainer>
+            <PaginationButton onClick={goToPrevPage}>
+              <img src={LeftIcon} alt="left" />
+            </PaginationButton>
+            {Array.from({ length: totalPages }).map((_, index) => (
+              <PageButton
+                key={index}
+                onClick={() => paginate(index + 1)}
+                isSelected={index + 1 === currentPage}
+              >
+                {index + 1}
+              </PageButton>
+            ))}
+            <PaginationButton onClick={goToNextPage}>
+              <img src={RightIcon} alt="right" />
+            </PaginationButton>
+        </PaginationContainer>
+      </div>
+    </div>
+  );
+};
+
+const PaginationContainer = styled.div`
+  display: flex;
+  align-items: center;
+  margin-top: 20px;
+  justify-content: center;
+  margin-bottom: 50px;
+`;
+
+const PaginationButton = styled.button`
+  background-color: transparent;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+  margin: 0 5px;
+`;
+
+const PageButton = styled.button`
+  border: none;
+  margin: 10px;
+  background-color: transparent;
+  color: ${(props) => (props.isSelected ? "#5263ff" : "#838383")};
+  font-size: 15px;
+`;

--- a/src/components/front/FrontList.jsx
+++ b/src/components/front/FrontList.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import styled from "styled-components";
 import FrontItem from "./FrontItem";
+import SearchBar from "./SearchBar";
 import usePagination from "../../hooks/usePagination";
 import LeftIcon from "../../assets/left.png";
 import RightIcon from "../../assets/right.png";
@@ -112,6 +113,7 @@ export default function FrontList() {
           </SortButton>
         </SortOptions>
 
+        <SearchBar />
       </Container>
 
       {/* 필터링된 스터디 리스트 표시 */}

--- a/src/components/front/FrontList.jsx
+++ b/src/components/front/FrontList.jsx
@@ -1,9 +1,23 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import styled from "styled-components";
 import FrontItem from "./FrontItem";
 import usePagination from "../../hooks/usePagination";
 import LeftIcon from "../../assets/left.png";
 import RightIcon from "../../assets/right.png";
+
+function isEqual(arr1, arr2) {
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+
+  for (let i = 0; i < arr1.length; i++) {
+    if (arr1[i].id !== arr2[i].id) {
+      return false;
+    }
+  }
+
+  return true;
+}
 
 export default function FrontList() {
   // 임시 프론트 문제집 data 
@@ -28,7 +42,7 @@ export default function FrontList() {
     {id: 18, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-09-28", user: "소밍밍", like: 10, cmt: 50},
     {id: 19, title: "정보처리기사실기_2023정보처리기사실기_2023", date: "2023-09-27", user: "소밍밍", like: 10, cmt: 11},
   ];
-
+  const [sortOption, setSortOption] = useState('latest'); // 초기 정렬 기준 : 최신순
   const [data, setData] = useState(frontData); // 데이터 상태 정의
 
   const itemsPerPage = 15; // 페이지 당 보여줄 아이템 수
@@ -44,8 +58,62 @@ export default function FrontList() {
     itemsPerPage
   );
 
+  useEffect(() => {
+    // 문제집 리스트 정렬
+    const sortData = (sortKey) => {
+      const sortedData = [...data]; // 원본 데이터를 변경하지 않기 위해 복사
+
+      if (sortKey === 'latest') {
+        sortedData.sort((a, b) => new Date(b.date) - new Date(a.date)); // 최신순
+      } else if (sortKey === 'oldest') {
+        sortedData.sort((a, b) => new Date(a.date) - new Date(b.date)); // 등록순
+      } else if (sortKey === 'highestRated') {
+        sortedData.sort((a, b) => b.like - a.like);                     // 평점 높은순
+      } else if (sortKey === 'mostCommented') {
+        sortedData.sort((a, b) => b.cmt - a.cmt);                       // 댓글순
+      }
+
+      return sortedData;
+    };
+    const sortedData = sortData(sortOption);
+    // 정렬된 데이터와 현재 데이터가 다를 경우에만 업데이트
+    if (!isEqual(sortedData, data)) {
+      setData(sortedData);
+    }
+  }, [sortOption, data]);
+
   return(
     <div>
+      <Container>
+        <SortOptions>
+          <SortButton
+            onClick={() => setSortOption('latest')}
+            active={sortOption === 'latest'}
+          >
+            최신순
+          </SortButton>
+          <SortButton
+            onClick={() => setSortOption('oldest')}
+            active={sortOption === 'oldest'}
+          >
+            등록순
+          </SortButton>
+          <SortButton
+            onClick={() => setSortOption('highestRated')}
+            active={sortOption === 'highestRated'}
+          >
+            평점 높은순
+          </SortButton>
+          <SortButton
+            onClick={() => setSortOption('mostCommented')}
+            active={sortOption === 'mostCommented'}
+          >
+            댓글순
+          </SortButton>
+        </SortOptions>
+
+      </Container>
+
       {/* 필터링된 스터디 리스트 표시 */}
       <div>
         {/* 현재 페이지의 아이템 렌더링 */}
@@ -75,6 +143,27 @@ export default function FrontList() {
     </div>
   );
 };
+
+const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const SortOptions = styled.div`
+  align-items: center;
+  display: flex;
+  padding: 5px 0;
+`;
+
+const SortButton = styled.button`
+  margin-right: 15spx;
+  background-color: transparent;
+  color: ${(props) => (props.active ? '#FFFFFF' : '#838383')};
+  font-size: 16px;
+  border: none;
+  cursor: pointer;
+`;
 
 const PaginationContainer = styled.div`
   display: flex;

--- a/src/components/front/FrontList.jsx
+++ b/src/components/front/FrontList.jsx
@@ -116,7 +116,7 @@ export default function FrontList() {
         <SearchBar />
       </Container>
 
-      {/* 필터링된 스터디 리스트 표시 */}
+      {/* 필터링된 프론트 문제집 리스트 표시 */}
       <div>
         {/* 현재 페이지의 아이템 렌더링 */}
         {currentItems.map((front, index) => (

--- a/src/components/front/SearchBar.jsx
+++ b/src/components/front/SearchBar.jsx
@@ -1,0 +1,49 @@
+import styled from "styled-components";
+import SearchIcon from "../../assets/search.png";
+import SelectBox from "../study/SelectBox";
+
+export default function SearchBar() {
+  return (
+    <SearchSection>
+      <SelectBox />
+      <SearchInputWrapper>
+        <SearchInput placeholder="검색어를 입력하세요." name="search" />
+        <SearchImg src={SearchIcon} alt="검색아이콘" />
+      </SearchInputWrapper>
+    </SearchSection>
+  );
+}
+
+const SearchSection = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 20px 0;
+  justify-content: flex-end;
+  z-index: 1;
+`;
+
+const SearchInputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  background-color: #3f424e;
+  padding: 5px;
+`;
+
+const SearchInput = styled.input`
+  border: none;
+  outline: none;
+  padding: 5px;
+  background: transparent;
+  width: 200px;
+  margin-left: 5px;
+  color: #fff;
+
+  &::placeholder {
+    color: #fff;
+  }
+`;
+
+const SearchImg = styled.img`
+  width: 20px;
+  margin-right: 5px;
+`;

--- a/src/components/front/Tooltip.jsx
+++ b/src/components/front/Tooltip.jsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import styled from "styled-components";
+import help from "../../assets/help.png";
+
+const Tooltip = () => {
+    const [hover, setHover] = useState(false);
+
+    const handleMouseEnter = () => {
+        setHover(true);
+    }
+    const handleMouseLeave = () => {
+        setHover(false);
+    }
+
+    return(
+        <TooltipContainer
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}>
+            <HelpImg src={help} alt="help" />
+            {hover && (<Description className="description">
+                문제집을 본인이 직접 만들고 싶다면 마이페이지에서 만들 수 있습니다.
+            </Description>)}
+        </TooltipContainer>
+    );
+};
+
+const TooltipContainer = styled.div`
+    display: inline-block;
+    position: relative;
+    cursor: pointer;
+    padding: 3.4px 10px 7px;
+
+    &.hover .description{
+        display: block;
+    }
+`;
+
+const HelpImg = styled.img`
+    display: block;
+`;
+
+const Description = styled.div`
+    display: block;
+    background-color: #3F424E;
+    font-size: 10px;
+    margin-top: 15px;
+    padding: 3px;
+    bottom: 0;
+    top: 100%;
+    left: 0;
+    white-space: nowrap;
+`;
+
+export default Tooltip;

--- a/src/pages/FrontMain.jsx
+++ b/src/pages/FrontMain.jsx
@@ -1,5 +1,40 @@
+import styled from "styled-components";
+import Tooltip from "../components/front/Tooltip";
+import FrontList from "../components/front/FrontList";
+
 const FrontMain = () => {
-  return <div>프론트엔드 메인 페이지입니다</div>;
+  return (
+    <Wrapper>
+      <TitleContent>
+        <Title>프론트엔드 문제집</Title>
+        <Tooltip />
+      </TitleContent>
+
+      <div>
+        <FrontList  />
+      </div>
+    </Wrapper>
+  );
 };
+
+const Wrapper = styled.div`
+  max-width: 1090px;
+  margin: 0 auto;
+`;
+
+const TitleContent = styled.div`
+  display: flex;
+  position: relative;
+  align-items: flex-start;
+  height: 60px;
+  margin-bottom: 30px;
+`;
+
+const Title = styled.div`
+  front-size: 20px;
+  front-weight: bold;
+  position: sticky;
+  top: 0;
+`;
 
 export default FrontMain;


### PR DESCRIPTION
## PR 타입
UI 구현

## 반영 브랜치
ui/#10 => develop<br/>
closed #10

## 변경 사항
![image](https://github.com/QuizUpWebProject/front/assets/71203375/bd762f44-0edc-4043-88ba-357b8e394d7e)
- '프론트엔드 문제집' UI 구현
- 마우스 hover 시 Tooltip 구현
- 임시 data로 FrontList 구현
- 최신순/등록순/평점높은순/댓글순 정렬 기능 구현 (임시 data 사용)
- 학습하기 버튼 클릭 시 '프론트엔드 문제집 메인' 페이지로 이동