### PR TITLE
[UI] 스터디방 만들기 페이지 UI 구현 (#19)

### DIFF
--- a/src/components/studyroomMake/SelectCategory.jsx
+++ b/src/components/studyroomMake/SelectCategory.jsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import styled from "styled-components";
+import DropDownIcon from "../../assets/dropdown2.png";
+
+export default function SelectCategory() {
+  const [isShowOption, setShowOptions] = useState(false);
+  const [currentValue, setCurrentValue] = useState("카테고리 선택");
+
+  const handleSelectValue = (e) => {
+    const { innerText } = e.target;
+    setCurrentValue(innerText);
+  };
+
+  return (
+    <SelectContainer onClick={() => setShowOptions((prev) => !prev)}>
+      <Label>
+        {currentValue}
+        <Icon src={DropDownIcon} alt="dropdown" />
+      </Label>
+      <SelectOptions show={isShowOption}>
+        <Option onClick={handleSelectValue}>프론트엔드</Option>
+        <Option onClick={handleSelectValue}>백엔드</Option>
+      </SelectOptions>
+    </SelectContainer>
+  );
+}
+
+const SelectContainer = styled.div`
+  position: relative;
+  width: 866px;
+  height: 42px;
+  padding: 8px;
+  background-color: #3f424e;
+  align-self: center;
+  border-radius: 6px;
+  cursor: pointer;
+`;
+
+const Label = styled.label`
+  font-size: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-right: 20px;
+  margin-top: 10px;
+`;
+
+const Icon = styled.img`
+  margin-left: 2d5px;
+  margin-right: 20px;
+  //margin-top: 15px;
+`;
+
+const SelectOptions = styled.ul`
+  position: absolute;
+  list-style: none;
+  top: 18px;
+  left: 0;
+  width: 100%;
+  overflow: hidden;
+  height: 90px;
+  max-height: ${(props) => (props.show ? "none" : "0")};
+  padding: 0;
+  border-radius: 8px;
+  background-color: #222222;
+  color: #fefefe;
+  transition: max-height 0.2s ease-in-out;
+`;
+
+const Option = styled.li`
+  font-size: 14px;
+  padding: 6px 8px;
+  text-align: center;
+  margin-top: 10px;
+  transition: background-color 0.2s ease-in;
+  &:hover {
+    background-color: #595959;
+  }
+`;

--- a/src/components/studyroomMake/SelectCategory.jsx
+++ b/src/components/studyroomMake/SelectCategory.jsx
@@ -29,11 +29,12 @@ const SelectContainer = styled.div`
   position: relative;
   width: 866px;
   height: 42px;
-  padding: 8px;
+  padding: 5px;
   background-color: #3f424e;
   align-self: center;
   border-radius: 6px;
   cursor: pointer;
+  z-index: 1;
 `;
 
 const Label = styled.label`

--- a/src/components/studyroomMake/SelectPeople.jsx
+++ b/src/components/studyroomMake/SelectPeople.jsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import styled from "styled-components";
+import DropDownIcon from "../../assets/dropdown2.png";
+
+export default function SelectPeople() {
+  const [isShowOption, setShowOptions] = useState(false);
+  const [currentValue, setCurrentValue] = useState("인원수 선택 (1 ~ 50명)");
+
+  const handleSelectValue = (e) => {
+    const { innerText } = e.target;
+    setCurrentValue(innerText);
+  };
+
+  return (
+    <SelectContainer onClick={() => setShowOptions((prev) => !prev)}>
+      <Label>
+        {currentValue}
+        <Icon src={DropDownIcon} alt="dropdown" />
+      </Label>
+      <SelectOptions show={isShowOption}>
+        {Array.from({ length: 50 }, (_, index) => (
+          <Option key={index} onClick={handleSelectValue}>
+            {index + 1}
+          </Option>
+        ))}
+      </SelectOptions>
+    </SelectContainer>
+  );
+}
+
+const SelectContainer = styled.div`
+  position: relative;
+  width: 866px;
+  height: 42px;
+  padding: 8px;
+  background-color: #3f424e;
+  align-self: center;
+  border-radius: 6px;
+  cursor: pointer;
+`;
+
+const Label = styled.label`
+  font-size: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-right: 20px;
+  margin-top: 10px;
+`;
+
+const Icon = styled.img`
+  margin-left: 2d5px;
+  margin-right: 20px;
+  //margin-top: 15px;
+`;
+
+const SelectOptions = styled.ul`
+  position: absolute;
+  list-style: none;
+  top: 18px;
+  left: 0;
+  width: 100%;
+  overflow: hidden;
+  height: 130px;
+  max-height: ${(props) => (props.show ? "none" : "0")};
+  overflow-y: auto;
+  padding: 0;
+  border-radius: 8px;
+  background-color: #222222;
+  color: #fefefe;
+  transition: max-height 0.2s ease-in-out;
+
+  /* Webkit (Chrome, Safari) 스크롤바 스타일링 */
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: #5263ff; /* 스크롤바 색상 */
+    border-radius: 10px;
+  }
+
+  /* Firefox 스크롤바 스타일링 */
+  scrollbar-width: thin;
+  scrollbar-color: #5263ff transparent;
+
+  & {
+    scrollbar-color: #5263ff transparent;
+  }
+`;
+
+const Option = styled.li`
+  font-size: 14px;
+  padding: 6px 8px;
+  text-align: center;
+  margin-top: 10px;
+  transition: background-color 0.2s ease-in;
+  &:hover {
+    background-color: #595959;
+  }
+`;

--- a/src/components/studyroomMake/SelectPeople.jsx
+++ b/src/components/studyroomMake/SelectPeople.jsx
@@ -32,11 +32,12 @@ const SelectContainer = styled.div`
   position: relative;
   width: 866px;
   height: 42px;
-  padding: 8px;
+  padding: 5px;
   background-color: #3f424e;
   align-self: center;
   border-radius: 6px;
   cursor: pointer;
+  z-index: 1;
 `;
 
 const Label = styled.label`

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -61,8 +61,10 @@ const Background = styled.div`
 `;
 
 const ModalBlock = styled.div`
-  position: absolute;
-  top: 6.5rem;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   border-radius: 13px;
   padding: 1.5rem;
   background-color: #262631;

--- a/src/pages/StudyMake.jsx
+++ b/src/pages/StudyMake.jsx
@@ -7,8 +7,11 @@ const StudyMake = () => {
     <Wrapper>
       <div>
         <div>그룹명*</div>
-        <input />
-        <button>중복 확인</button>
+        <div>
+          <GroupNameInput />
+          <ConfirmBtn>중복 확인</ConfirmBtn>
+        </div>
+        <div>사용 가능한 특수문자는 (_/-/@/.)입니다.</div>
       </div>
 
       <div>
@@ -27,7 +30,7 @@ const StudyMake = () => {
         <div>
           참여코드 (선택사항) 공개 스터디방으로 원할 경우 빈칸으로 제출하세요.
         </div>
-        <input
+        <CodeInput
           text="password"
           placeholder="참여코드 설정은 숫자 4자리 입니다."
         />
@@ -35,7 +38,7 @@ const StudyMake = () => {
 
       <div>
         <div>소개글</div>
-        <textarea placeholder="궁금할 스터디원들에게 어떤 스터디방인지 설명해주세요. ex) 규칙사항, 준비하는 문제에 대해 간략하게 적어보세요." />
+        <IntroduceArea placeholder="궁금할 스터디원들에게 어떤 스터디방인지 설명해주세요. ex) 규칙사항, 준비하는 문제에 대해 간략하게 적어보세요." />
       </div>
 
       <MakeBtn>방 만들기</MakeBtn>
@@ -50,6 +53,63 @@ const Wrapper = styled.div`
   margin: 0 auto;
 `;
 
+const GroupNameInput = styled.input`
+  width: 642px;
+  height: 42px;
+  padding: 5px;
+  background-color: #3f424e;
+  border: none;
+  border-radius: 6px;
+  margin-right: 20px;
+  color: #ffffff;
+`;
+
+const ConfirmBtn = styled.button`
+  width: 180px;
+  height: 42px;
+  border: none;
+  border-radius: 5px;
+  background-color: #5263ff;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 600;
+  margin-left: 20px;
+`;
+
+const CodeInput = styled.input`
+  width: 866px;
+  height: 42px;
+  padding: 5px;
+  background-color: #3f424e;
+  border: none;
+  border-radius: 6px;
+  color: #ffffff;
+
+  &::placeholder {
+    color: #ffffff;
+    padding: 5px;
+    font-size: 14px;
+    font-weight: 400;
+  }
+`;
+
+const IntroduceArea = styled.textarea`
+  width: 866px;
+  height: 93px;
+  padding: 5px;
+  background-color: #3f424e;
+  border: none;
+  border-radius: 6px;
+  color: #ffffff;
+
+  &::placeholder {
+    color: #ffffff;
+    padding: 5px;
+    font-size: 14px;
+    font-weight: 400;
+  }
+`;
+
 const MakeBtn = styled.button`
   width: 866px;
   height: 39px;
@@ -57,4 +117,6 @@ const MakeBtn = styled.button`
   border-radius: 6px;
   background-color: #5263ff;
   color: #ffffff;
+  font-size: 14px;
+  font-weight: 500;
 `;

--- a/src/pages/StudyMake.jsx
+++ b/src/pages/StudyMake.jsx
@@ -1,5 +1,47 @@
+import styled from "styled-components";
+
 const StudyMake = () => {
-  return <div>스터디방 만들기 페이지입니다</div>;
+  return (
+    <Wrapper>
+      <div>
+        <div>그룹명*</div>
+        <input />
+        <button>중복 확인</button>
+      </div>
+
+      <div>
+        <div>그룹 카테고리*</div>
+        {/* select (front/back) */}
+      </div>
+
+      <div>
+        <div>제한 인원수*</div>
+        {/* select (1~50) */}
+      </div>
+
+      <div>
+        <div>
+          참여코드 (선택사항) 공개 스터디방으로 원할 경우 빈칸으로 제출하세요.
+        </div>
+        <input
+          text="password"
+          placeholder="참여코드 설정은 숫자 4자리 입니다."
+        />
+      </div>
+
+      <div>
+        <div>소개글</div>
+        <textarea placeholder="궁금할 스터디원들에게 어떤 스터디방인지 설명해주세요. ex) 규칙사항, 준비하는 문제에 대해 간략하게 적어보세요." />
+      </div>
+
+      <button>방 만들기</button>
+    </Wrapper>
+  );
 };
 
 export default StudyMake;
+
+const Wrapper = styled.div`
+  max-width: 1090px;
+  margin: 0 auto;
+`;

--- a/src/pages/StudyMake.jsx
+++ b/src/pages/StudyMake.jsx
@@ -1,4 +1,6 @@
 import styled from "styled-components";
+import SelectCategory from "../components/studyroomMake/SelectCategory";
+import SelectPeople from "../components/studyroomMake/SelectPeople";
 
 const StudyMake = () => {
   return (
@@ -12,11 +14,13 @@ const StudyMake = () => {
       <div>
         <div>그룹 카테고리*</div>
         {/* select (front/back) */}
+        <SelectCategory />
       </div>
 
       <div>
         <div>제한 인원수*</div>
         {/* select (1~50) */}
+        <SelectPeople />
       </div>
 
       <div>
@@ -34,7 +38,7 @@ const StudyMake = () => {
         <textarea placeholder="궁금할 스터디원들에게 어떤 스터디방인지 설명해주세요. ex) 규칙사항, 준비하는 문제에 대해 간략하게 적어보세요." />
       </div>
 
-      <button>방 만들기</button>
+      <MakeBtn>방 만들기</MakeBtn>
     </Wrapper>
   );
 };
@@ -44,4 +48,13 @@ export default StudyMake;
 const Wrapper = styled.div`
   max-width: 1090px;
   margin: 0 auto;
+`;
+
+const MakeBtn = styled.button`
+  width: 866px;
+  height: 39px;
+  border: none;
+  border-radius: 6px;
+  background-color: #5263ff;
+  color: #ffffff;
 `;

--- a/src/pages/StudyMake.jsx
+++ b/src/pages/StudyMake.jsx
@@ -2,12 +2,19 @@ import styled from "styled-components";
 import SelectCategory from "../components/studyroomMake/SelectCategory";
 import SelectPeople from "../components/studyroomMake/SelectPeople";
 import { useState } from "react";
+import useModal from "../hooks/useModal";
 
 const StudyMake = () => {
   const [isDuplicate, setIsDuplicate] = useState(false); // 중복 확인 상태관리
   const [code, setCode] = useState(""); // 비공개 코드 상태관리
   const [isCodeValid, setIsCodeValid] = useState(true); // 비공개 코드 유효성 검사
   const [introduction, setIntroduction] = useState(""); // textarea 글자 제한 유효성 검사
+  const [groupName, setGroupName] = useState(""); // 그룹명 상태관리
+  const [category, setCategory] = useState(""); // 카테고리 상태관리
+  const [peopleLimit, setPeopleLimit] = useState(""); // 제한 인원수 상태관리
+
+  // useModal 사용해서 그룹방 탈퇴 모달 구현
+  const { openModal, Modal } = useModal();
 
   // 중복 확인 버튼
   const handleCheckDuplicate = () => {
@@ -29,7 +36,41 @@ const StudyMake = () => {
     setIntroduction(inputValue);
   };
 
+  // 그룹명 입력 시 상태 업데이트
+  const handleGroupName = (event) => {
+    const inputValue = event.target.value;
+    setGroupName(inputValue);
+  };
+
+  // 카테고리 선택 시 상태 업데이트
+  const handleCategory = (selectedCategory) => {
+    setCategory(selectedCategory);
+  };
+
+  // 제한 인원수 선택 시 상태 업데이트
+  const handlePeopleLimit = (selectedLimit) => {
+    setPeopleLimit(selectedLimit);
+  };
+
+  // 버튼 활성화 조건
+  // const isButtonEnabled =
+  //   groupName !== "" && category !== "" && peopleLimit !== "";
+
+  // textarea 글자수 제한
   const isIntroductionTooLong = introduction.length > 100000;
+
+  // 만들기 btn 클릭
+  const handleCreateStudy = () => {
+    // if (!isButtonEnabled) {
+    //   alert("그룹명, 카테고리, 제한 인원수를 모두 입력해야 합니다");
+    //   return;
+    // }
+
+    // modal open
+    openModal();
+
+    console.log("click");
+  };
 
   return (
     <Wrapper>
@@ -38,7 +79,7 @@ const StudyMake = () => {
           그룹명<span>*</span>
         </Title>
         <GroupNameContainer>
-          <GroupNameInput />
+          <GroupNameInput value={groupName} onChange={handleGroupName} />
           <ConfirmBtn onClick={handleCheckDuplicate}>중복 확인</ConfirmBtn>
         </GroupNameContainer>
         <GrouptNameText>사용 가능한 특수문자는 (_/-/@/.)입니다.</GrouptNameText>
@@ -54,7 +95,10 @@ const StudyMake = () => {
           그룹 카테고리<span>*</span>
         </Title>
         {/* select (front/back) */}
-        <SelectCategory />
+        <SelectCategory
+          selectedCategory={category}
+          onCategoryChange={handleCategory}
+        />
       </Container>
 
       <Container>
@@ -62,7 +106,10 @@ const StudyMake = () => {
           제한 인원수<span>*</span>
         </Title>
         {/* select (1~50) */}
-        <SelectPeople />
+        <SelectPeople
+          selectedLimit={peopleLimit}
+          onPeopleLimitChange={handlePeopleLimit}
+        />
       </Container>
 
       <Container>
@@ -100,7 +147,17 @@ const StudyMake = () => {
         )}
       </Container>
 
-      <MakeBtn>방 만들기</MakeBtn>
+      <MakeBtn onClick={handleCreateStudy}>방 만들기</MakeBtn>
+
+      {/* modal */}
+      <Modal style={{ width: "400px", height: "220px" }}>
+        <ModalContent>
+          <div>
+            <ModalBody>축하합니다! 스터디방이 만들어졌습니다.</ModalBody>
+          </div>
+          <Button>스터디방으로 이동하기</Button>
+        </ModalContent>
+      </Modal>
     </Wrapper>
   );
 };
@@ -247,4 +304,33 @@ const MakeBtn = styled.button`
   font-weight: 500;
   margin-top: 20px;
   margin-bottom: 50px;
+`;
+
+const ModalContent = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  margin-top: 60px;
+  font-size: 14px;
+  text-align: center;
+`;
+
+const ModalBody = styled.div`
+  margin-bottom: 20px;
+  color: #c7c7c7;
+  text-align: center;
+  margin-bottom: 30px;
+`;
+
+const Button = styled.button`
+  width: 301px;
+  height: 37px;
+  background-color: #5263ff;
+  font-size: 14px;
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  margin-top: 20px;
 `;

--- a/src/pages/StudyMake.jsx
+++ b/src/pages/StudyMake.jsx
@@ -7,6 +7,7 @@ const StudyMake = () => {
   const [isDuplicate, setIsDuplicate] = useState(false); // 중복 확인 상태관리
   const [code, setCode] = useState(""); // 비공개 코드 상태관리
   const [isCodeValid, setIsCodeValid] = useState(true); // 비공개 코드 유효성 검사
+  const [introduction, setIntroduction] = useState(""); // textarea 글자 제한 유효성 검사
 
   // 중복 확인 버튼
   const handleCheckDuplicate = () => {
@@ -22,6 +23,13 @@ const StudyMake = () => {
     setIsCodeValid(isValid);
     setCode(inputValue);
   };
+
+  const handleIntroduction = (event) => {
+    const inputValue = event.target.value;
+    setIntroduction(inputValue);
+  };
+
+  const isIntroductionTooLong = introduction.length > 100000;
 
   return (
     <Wrapper>
@@ -79,7 +87,17 @@ const StudyMake = () => {
 
       <Container>
         <Title>소개글</Title>
-        <IntroduceArea placeholder="궁금할 스터디원들에게 어떤 스터디방인지 설명해주세요. ex) 규칙사항, 준비하는 문제에 대해 간략하게 적어보세요." />
+        <IntroduceArea
+          placeholder="궁금할 스터디원들에게 어떤 스터디방인지 설명해주세요. ex) 규칙사항, 준비하는 문제에 대해 간략하게 적어보세요."
+          value={introduction}
+          onChange={handleIntroduction}
+        />
+        <CharCountText>{introduction.length} / 100,000</CharCountText>
+        {isIntroductionTooLong && (
+          <IntroductionErrorMessage>
+            해당 글자수를 초과하였습니다. 글자수를 줄여주세요.
+          </IntroductionErrorMessage>
+        )}
       </Container>
 
       <MakeBtn>방 만들기</MakeBtn>
@@ -202,6 +220,20 @@ const IntroduceArea = styled.textarea`
     font-size: 14px;
     font-weight: 400;
   }
+`;
+
+const CharCountText = styled.div`
+  font-size: 13px;
+  color: #939393;
+  margin-top: 5px;
+  text-align: right;
+`;
+
+const IntroductionErrorMessage = styled.div`
+  font-size: 13px;
+  font-weight: 600;
+  color: #ff0000;
+  margin-top: 5px;
 `;
 
 const MakeBtn = styled.button`

--- a/src/pages/StudyMake.jsx
+++ b/src/pages/StudyMake.jsx
@@ -1,45 +1,86 @@
 import styled from "styled-components";
 import SelectCategory from "../components/studyroomMake/SelectCategory";
 import SelectPeople from "../components/studyroomMake/SelectPeople";
+import { useState } from "react";
 
 const StudyMake = () => {
+  const [isDuplicate, setIsDuplicate] = useState(false); // 중복 확인 상태관리
+  const [code, setCode] = useState(""); // 비공개 코드 상태관리
+  const [isCodeValid, setIsCodeValid] = useState(true); // 비공개 코드 유효성 검사
+
+  // 중복 확인 버튼
+  const handleCheckDuplicate = () => {
+    // 중복 확인 로직 추가 예정
+    setIsDuplicate(true);
+  };
+
+  const handleCode = (event) => {
+    const inputValue = event.target.value;
+
+    // 정규식으로 유효성 검사
+    const isValid = /^\d{4}$/.test(inputValue);
+    setIsCodeValid(isValid);
+    setCode(inputValue);
+  };
+
   return (
     <Wrapper>
-      <div>
-        <div>그룹명*</div>
-        <div>
+      <Container>
+        <Title>
+          그룹명<span>*</span>
+        </Title>
+        <GroupNameContainer>
           <GroupNameInput />
-          <ConfirmBtn>중복 확인</ConfirmBtn>
-        </div>
-        <div>사용 가능한 특수문자는 (_/-/@/.)입니다.</div>
-      </div>
+          <ConfirmBtn onClick={handleCheckDuplicate}>중복 확인</ConfirmBtn>
+        </GroupNameContainer>
+        <GrouptNameText>사용 가능한 특수문자는 (_/-/@/.)입니다.</GrouptNameText>
+        {isDuplicate && (
+          <CheckText>
+            현재 입력한 그룹방은 이미 있는 그룹방 입니다. 새로 입력해주세요.
+          </CheckText>
+        )}
+      </Container>
 
-      <div>
-        <div>그룹 카테고리*</div>
+      <Container>
+        <Title>
+          그룹 카테고리<span>*</span>
+        </Title>
         {/* select (front/back) */}
         <SelectCategory />
-      </div>
+      </Container>
 
-      <div>
-        <div>제한 인원수*</div>
+      <Container>
+        <Title>
+          제한 인원수<span>*</span>
+        </Title>
         {/* select (1~50) */}
         <SelectPeople />
-      </div>
+      </Container>
 
-      <div>
-        <div>
-          참여코드 (선택사항) 공개 스터디방으로 원할 경우 빈칸으로 제출하세요.
-        </div>
+      <Container>
+        <CodeTitle>
+          참여코드{"   "}
+          <CodeText>
+            (선택사항) 공개 스터디방으로 원할 경우 빈칸으로 제출하세요.
+          </CodeText>
+        </CodeTitle>
         <CodeInput
-          text="password"
+          type="password"
           placeholder="참여코드 설정은 숫자 4자리 입니다."
+          value={code}
+          onChange={handleCode}
         />
-      </div>
+        {!isCodeValid && (
+          <CodeErrorMessage>
+            참여코드는 4자리 숫자로 입력해야 합니다.
+          </CodeErrorMessage>
+        )}
+      </Container>
 
-      <div>
-        <div>소개글</div>
+      <Container>
+        <Title>소개글</Title>
         <IntroduceArea placeholder="궁금할 스터디원들에게 어떤 스터디방인지 설명해주세요. ex) 규칙사항, 준비하는 문제에 대해 간략하게 적어보세요." />
-      </div>
+      </Container>
 
       <MakeBtn>방 만들기</MakeBtn>
     </Wrapper>
@@ -51,6 +92,27 @@ export default StudyMake;
 const Wrapper = styled.div`
   max-width: 1090px;
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const Container = styled.div`
+  margin-bottom: 50px;
+`;
+
+const Title = styled.div`
+  fontsize: 16px;
+  font-weight: 600;
+  margin-bottom: 15px;
+
+  span {
+    color: #ff0000;
+  }
+`;
+
+const GroupNameContainer = styled.div`
+  margin-bottom: 15px;
 `;
 
 const GroupNameInput = styled.input`
@@ -76,6 +138,18 @@ const ConfirmBtn = styled.button`
   margin-left: 20px;
 `;
 
+const GrouptNameText = styled.div`
+  font-size: 13px;
+  font-weight: 400;
+  color: #939393;
+`;
+
+const CheckText = styled.div`
+  font-size: 13px;
+  font-weight: 400;
+  color: #ff0000;
+`;
+
 const CodeInput = styled.input`
   width: 866px;
   height: 42px;
@@ -91,6 +165,26 @@ const CodeInput = styled.input`
     font-size: 14px;
     font-weight: 400;
   }
+`;
+
+const CodeTitle = styled.div`
+  fontsize: 16px;
+  font-weight: 600;
+  margin-bottom: 15px;
+`;
+
+const CodeText = styled.span`
+  font-size: 10px;
+  font-weight: 400;
+  color: #939393;
+  margin-left: 10px;
+`;
+
+const CodeErrorMessage = styled.div`
+  font-size: 13px;
+  font-weight: 600;
+  color: #ff0000;
+  margin-top: 5px;
 `;
 
 const IntroduceArea = styled.textarea`
@@ -119,4 +213,6 @@ const MakeBtn = styled.button`
   color: #ffffff;
   font-size: 14px;
   font-weight: 500;
+  margin-top: 20px;
+  margin-bottom: 50px;
 `;


### PR DESCRIPTION
## PR 타입
UI 구현

## 반영 브랜치
ui/#19 => develop

closed #19 

## 변경 사항
![localhost_3000_studymake](https://github.com/QuizUpWebProject/front/assets/95006849/ad83bf31-434d-4719-b5f1-dda50cc481cd)
- 그룹명
   - 중복 확인 버튼 클릭 시 중복되면 경고 문구 작성 (현재는 기능 구현 X) 
- 카테고리
   - selectBox로 프론트엔드/백엔드 선택 가능
- 인원수
   - selectBox로 1~50명 인원 선택 가능
- 코드 (선택사항)
    - 유효성 검사를 통해 4자리의 숫자만 가능하도록 기능 추가
    - 비밀번호 형식으로 보이지 않도록 type 지정
- 소개글 (선택사항)
   - 10,000자 제한 (유효성 검사 추가)
   - 실시간으로 글자 수 반영되도록 아래 글자수 안내 추가
- 방 만들기 버튼
   - 버튼 클릭 시 완료되었다는 모달창 구현