### PR TITLE
[UI] 회원가입 정보입력 페이지 UI 구현(#8)

### DIFF
--- a/src/components/join/EmailCheck.jsx
+++ b/src/components/join/EmailCheck.jsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import styled from "styled-components";
+import useModal from "../../hooks/useModal";
+
+export default function EmailCheck() {
+  const { openModal, Modal, closeModal } = useModal();
+
+  // 아이디 중복 확인
+  const [email, setEmail] = useState("");
+  const emailRegex = /^[\w._%+-]+@[\w.-]+\.[a-zA-Z]{2,4}$/;
+  const [isValid, setIsValid] = useState(true); // 유효성 검사
+
+  const handleCheckEmail = () => {
+    const checkedEmail = emailRegex.test(email); // 유효성 검사한 email
+
+    setIsValid(checkedEmail);
+
+    if (!emailRegex.test(email)) {
+      // 중복 확인 관련 기능 추가 예정
+      openModal();
+    } else {
+      // 중복 확인 후 맞으면? 우선 alert 생성
+      alert("확인되었습니다.");
+    }
+  };
+
+  return (
+    <>
+      <Container>
+        <Label>
+          아이디<span>*</span>
+        </Label>
+        <div>
+          <SInput
+            placeholder="이메일을 입력해주세요."
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <CheckBtn onClick={handleCheckEmail}>중복 확인</CheckBtn>
+        </div>
+        <Text
+          style={{
+            color: isValid ? "#939393" : "#ff0000",
+          }}
+        >
+          사용 가능한 특수문자는 (_/-/@/.)입니다.
+        </Text>
+      </Container>
+
+      {/* 아이디 중복 확인 modal */}
+      <Modal style={{ width: "400px", height: "220px" }}>
+        <ModalContent>
+          <div>
+            <ModalBody>이메일 형식이 올바르지 않습니다.</ModalBody>
+          </div>
+          <ModalButton onClick={closeModal}>확인</ModalButton>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}
+
+const Container = styled.div`
+  margin-bottom: 30px;
+`;
+
+const Label = styled.div`
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 19.5px;
+  margin-bottom: 14px;
+
+  span {
+    color: #ff0000;
+  }
+`;
+
+const SInput = styled.input`
+  width: 642px;
+  height: 42px;
+  background-color: #3f424e;
+  border: none;
+  border-radius: 6px;
+  color: #ffffff;
+  padding: 5px;
+  margin-bottom: 15px;
+  margin-right: 20px;
+
+  &::placeholder {
+    color: #ffffff;
+    font-size: 14px;
+    font-weight: 400;
+    padding: 5px;
+  }
+`;
+
+const CheckBtn = styled.button`
+  width: 180px;
+  height: 42px;
+  border: none;
+  border-radius: 5px;
+  background-color: #5263ff;
+  color: #ffffff;
+  margin-left: 20px;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 29px;
+`;
+
+const Text = styled.div`
+  color: #939393;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 29px;
+  margin-bottom: 15px;
+`;
+
+const ModalContent = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  margin-top: 60px;
+  font-size: 14px;
+  text-align: center;
+`;
+
+const ModalBody = styled.div`
+  margin-bottom: 20px;
+  color: #c7c7c7;
+  text-align: center;
+  margin-bottom: 30px;
+`;
+
+const ModalButton = styled.button`
+  width: 301px;
+  height: 37px;
+  background-color: #5263ff;
+  font-size: 14px;
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  margin-top: 20px;
+`;

--- a/src/components/join/EmailCheck.jsx
+++ b/src/components/join/EmailCheck.jsx
@@ -2,11 +2,11 @@ import { useState } from "react";
 import styled from "styled-components";
 import useModal from "../../hooks/useModal";
 
-export default function EmailCheck() {
+export default function EmailCheck({ email, setEmail }) {
   const { openModal, Modal, closeModal } = useModal();
 
   // 아이디 중복 확인
-  const [email, setEmail] = useState("");
+  //const [email, setEmail] = useState("");
   const emailRegex = /^[\w._%+-]+@[\w.-]+\.[a-zA-Z]{2,4}$/;
   const [isValid, setIsValid] = useState(true); // 유효성 검사
 

--- a/src/components/join/JoinForm.jsx
+++ b/src/components/join/JoinForm.jsx
@@ -1,8 +1,25 @@
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
+import useModal from "../../hooks/useModal";
 
 export default function JoinForm() {
   const navigate = useNavigate();
+
+  // 아이디 중복 확인
+  const [email, setEmail] = useState("");
+  const { openModal, Modal, closeModal } = useModal();
+
+  const handleCheckEmail = () => {
+    const emailRegex = /^[\w._%+-]+@[\w.-]+\.[a-zA-Z]{2,4}$/;
+
+    if (!emailRegex.test(email)) {
+      openModal();
+    } else {
+      // 중복 확인 후 맞으면? 우선 alert 생성
+      alert("확인되었습니다.");
+    }
+  };
 
   return (
     <Wrapper>
@@ -11,11 +28,25 @@ export default function JoinForm() {
           아이디<span>*</span>
         </Label>
         <div>
-          <SInput placeholder="이메일을 입력해주세요." />
-          <CheckBtn>중복 확인</CheckBtn>
+          <SInput
+            placeholder="이메일을 입력해주세요."
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <CheckBtn onClick={handleCheckEmail}>중복 확인</CheckBtn>
         </div>
         <Text>사용 가능한 특수문자는 (_/-/@/.)입니다.</Text>
       </Container>
+
+      {/* 아이디 중복 확인 modal */}
+      <Modal style={{ width: "400px", height: "220px" }}>
+        <ModalContent>
+          <div>
+            <ModalBody>이메일 형식이 올바르지 않습니다.</ModalBody>
+          </div>
+          <ModalButton onClick={closeModal}>확인</ModalButton>
+        </ModalContent>
+      </Modal>
 
       <Container>
         <Label>
@@ -134,4 +165,33 @@ const Button = styled.button`
   line-height: 29px;
   margin-top: 20px;
   margin-bottom: 20px;
+`;
+
+const ModalContent = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  margin-top: 60px;
+  font-size: 14px;
+  text-align: center;
+`;
+
+const ModalBody = styled.div`
+  margin-bottom: 20px;
+  color: #c7c7c7;
+  text-align: center;
+  margin-bottom: 30px;
+`;
+
+const ModalButton = styled.button`
+  width: 301px;
+  height: 37px;
+  background-color: #5263ff;
+  font-size: 14px;
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  margin-top: 20px;
 `;

--- a/src/components/join/JoinForm.jsx
+++ b/src/components/join/JoinForm.jsx
@@ -5,19 +5,38 @@ import useModal from "../../hooks/useModal";
 
 export default function JoinForm() {
   const navigate = useNavigate();
+  const { openModal, Modal, closeModal } = useModal();
 
   // 아이디 중복 확인
   const [email, setEmail] = useState("");
-  const { openModal, Modal, closeModal } = useModal();
+  const emailRegex = /^[\w._%+-]+@[\w.-]+\.[a-zA-Z]{2,4}$/;
+
+  // 비밀번호 확인
+  const [password, setPassword] = useState("");
+  const [passwordConfirm, setpasswordConfirm] = useState("");
+  const [isValid, setIsValid] = useState(true); // 비밀번호 유효성 검사
+  const [isError, setIsError] = useState(false); // 비밀번호 확인 후 안내 message
+  const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d|[\W_]).{8,13}$/;
 
   const handleCheckEmail = () => {
-    const emailRegex = /^[\w._%+-]+@[\w.-]+\.[a-zA-Z]{2,4}$/;
-
     if (!emailRegex.test(email)) {
       openModal();
     } else {
       // 중복 확인 후 맞으면? 우선 alert 생성
       alert("확인되었습니다.");
+    }
+  };
+
+  const handleCheckPassword = () => {
+    const isPasswordValid = passwordRegex.test(password);
+    const passwordsMatch = password === passwordConfirm;
+
+    setIsValid(isPasswordValid);
+
+    if (!passwordsMatch) {
+      setIsError(true);
+    } else {
+      setIsError(false);
     }
   };
 
@@ -52,11 +71,29 @@ export default function JoinForm() {
         <Label>
           비밀번호<span>*</span>
         </Label>
-        <Input placeholder="비밀번호를 입력해주세요. " />
-        <Text>
+        <Input
+          type="password"
+          placeholder="비밀번호를 입력해주세요. "
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <Text
+          style={{
+            color: isValid ? "#939393" : "#ff0000",
+          }}
+        >
           영문,숫자,특수문자 중 2가지 이상의 문자조합 8-13자로 입력해주세요.
         </Text>
-        <Input placeholder="비밀번호를 다시 한번 더 입력해주세요." />
+        <Input
+          type="password"
+          placeholder="비밀번호를 다시 한번 더 입력해주세요."
+          value={passwordConfirm}
+          onChange={(e) => setpasswordConfirm(e.target.value)}
+          onBlur={handleCheckPassword}
+        />
+        {isError && (
+          <PasswordMisMatch>비밀번호가 일치하지 않습니다.</PasswordMisMatch>
+        )}
       </Container>
 
       <Container>
@@ -151,6 +188,13 @@ const Text = styled.div`
   font-weight: 400;
   line-height: 29px;
   margin-bottom: 15px;
+`;
+
+const PasswordMisMatch = styled.div`
+  color: #ff0000;
+  font-weight: 600;
+  font-size: 14px;
+  margin-top: 10px;
 `;
 
 const Button = styled.button`

--- a/src/components/join/JoinForm.jsx
+++ b/src/components/join/JoinForm.jsx
@@ -1,0 +1,35 @@
+import { useNavigate } from "react-router-dom";
+
+export default function JoinForm() {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <div>
+        <div>
+          아이디<span>*</span>
+        </div>
+        <input />
+        <button>중복 확인</button>
+      </div>
+
+      <div>
+        <div>
+          비밀번호<span>*</span>
+        </div>
+        <input />
+        <input />
+      </div>
+
+      <div>
+        <div>
+          닉네임<span>*</span>
+        </div>
+        <input />
+        <button>중복 확인</button>
+      </div>
+
+      <button onClick={() => navigate("/joinend")}>가입완료</button>
+    </>
+  );
+}

--- a/src/components/join/JoinForm.jsx
+++ b/src/components/join/JoinForm.jsx
@@ -1,15 +1,11 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import useModal from "../../hooks/useModal";
+import EmailCheck from "./EmailCheck";
+import NicknameCheck from "./NicknameCheck";
 
 export default function JoinForm() {
   const navigate = useNavigate();
-  const { openModal, Modal, closeModal } = useModal();
-
-  // 아이디 중복 확인
-  const [email, setEmail] = useState("");
-  const emailRegex = /^[\w._%+-]+@[\w.-]+\.[a-zA-Z]{2,4}$/;
 
   // 비밀번호 확인
   const [password, setPassword] = useState("");
@@ -17,15 +13,6 @@ export default function JoinForm() {
   const [isValid, setIsValid] = useState(true); // 비밀번호 유효성 검사
   const [isError, setIsError] = useState(false); // 비밀번호 확인 후 안내 message
   const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d|[\W_]).{8,13}$/;
-
-  const handleCheckEmail = () => {
-    if (!emailRegex.test(email)) {
-      openModal();
-    } else {
-      // 중복 확인 후 맞으면? 우선 alert 생성
-      alert("확인되었습니다.");
-    }
-  };
 
   const handleCheckPassword = () => {
     const isPasswordValid = passwordRegex.test(password);
@@ -42,30 +29,7 @@ export default function JoinForm() {
 
   return (
     <Wrapper>
-      <Container>
-        <Label>
-          아이디<span>*</span>
-        </Label>
-        <div>
-          <SInput
-            placeholder="이메일을 입력해주세요."
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
-          <CheckBtn onClick={handleCheckEmail}>중복 확인</CheckBtn>
-        </div>
-        <Text>사용 가능한 특수문자는 (_/-/@/.)입니다.</Text>
-      </Container>
-
-      {/* 아이디 중복 확인 modal */}
-      <Modal style={{ width: "400px", height: "220px" }}>
-        <ModalContent>
-          <div>
-            <ModalBody>이메일 형식이 올바르지 않습니다.</ModalBody>
-          </div>
-          <ModalButton onClick={closeModal}>확인</ModalButton>
-        </ModalContent>
-      </Modal>
+      <EmailCheck />
 
       <Container>
         <Label>
@@ -96,16 +60,7 @@ export default function JoinForm() {
         )}
       </Container>
 
-      <Container>
-        <Label>
-          닉네임<span>*</span>
-        </Label>
-        <div>
-          <SInput placeholder="사용하실 닉네임을 입력해주세요." />
-          <CheckBtn>중복 확인</CheckBtn>
-        </div>
-        <Text>최대 5글자까지 허용 (특수문자는 사용하실 수 없습니다)</Text>
-      </Container>
+      <NicknameCheck />
 
       <Button onClick={() => navigate("/joinend")}>가입완료</Button>
     </Wrapper>
@@ -130,38 +85,6 @@ const Label = styled.div`
   span {
     color: #ff0000;
   }
-`;
-
-const SInput = styled.input`
-  width: 642px;
-  height: 42px;
-  background-color: #3f424e;
-  border: none;
-  border-radius: 6px;
-  color: #ffffff;
-  padding: 5px;
-  margin-bottom: 15px;
-  margin-right: 20px;
-
-  &::placeholder {
-    color: #ffffff;
-    font-size: 14px;
-    font-weight: 400;
-    padding: 5px;
-  }
-`;
-
-const CheckBtn = styled.button`
-  width: 180px;
-  height: 42px;
-  border: none;
-  border-radius: 5px;
-  background-color: #5263ff;
-  color: #ffffff;
-  margin-left: 20px;
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 29px;
 `;
 
 const Input = styled.input`
@@ -209,33 +132,4 @@ const Button = styled.button`
   line-height: 29px;
   margin-top: 20px;
   margin-bottom: 20px;
-`;
-
-const ModalContent = styled.div`
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  align-items: center;
-  height: 100%;
-  margin-top: 60px;
-  font-size: 14px;
-  text-align: center;
-`;
-
-const ModalBody = styled.div`
-  margin-bottom: 20px;
-  color: #c7c7c7;
-  text-align: center;
-  margin-bottom: 30px;
-`;
-
-const ModalButton = styled.button`
-  width: 301px;
-  height: 37px;
-  background-color: #5263ff;
-  font-size: 14px;
-  color: #ffffff;
-  border: none;
-  border-radius: 6px;
-  margin-top: 20px;
 `;

--- a/src/components/join/JoinForm.jsx
+++ b/src/components/join/JoinForm.jsx
@@ -1,35 +1,137 @@
 import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
 
 export default function JoinForm() {
   const navigate = useNavigate();
 
   return (
-    <>
-      <div>
-        <div>
+    <Wrapper>
+      <Container>
+        <Label>
           아이디<span>*</span>
-        </div>
-        <input />
-        <button>중복 확인</button>
-      </div>
-
-      <div>
+        </Label>
         <div>
+          <SInput placeholder="이메일을 입력해주세요." />
+          <CheckBtn>중복 확인</CheckBtn>
+        </div>
+        <Text>사용 가능한 특수문자는 (_/-/@/.)입니다.</Text>
+      </Container>
+
+      <Container>
+        <Label>
           비밀번호<span>*</span>
-        </div>
-        <input />
-        <input />
-      </div>
+        </Label>
+        <Input placeholder="비밀번호를 입력해주세요. " />
+        <Text>
+          영문,숫자,특수문자 중 2가지 이상의 문자조합 8-13자로 입력해주세요.
+        </Text>
+        <Input placeholder="비밀번호를 다시 한번 더 입력해주세요." />
+      </Container>
 
-      <div>
-        <div>
+      <Container>
+        <Label>
           닉네임<span>*</span>
+        </Label>
+        <div>
+          <SInput placeholder="사용하실 닉네임을 입력해주세요." />
+          <CheckBtn>중복 확인</CheckBtn>
         </div>
-        <input />
-        <button>중복 확인</button>
-      </div>
+        <Text>최대 5글자까지 허용 (특수문자는 사용하실 수 없습니다)</Text>
+      </Container>
 
-      <button onClick={() => navigate("/joinend")}>가입완료</button>
-    </>
+      <Button onClick={() => navigate("/joinend")}>가입완료</Button>
+    </Wrapper>
   );
 }
+
+const Wrapper = styled.div`
+  margin-top: 60px;
+  margin-bottom: 40px;
+`;
+
+const Container = styled.div`
+  margin-bottom: 30px;
+`;
+
+const Label = styled.div`
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 19.5px;
+  margin-bottom: 14px;
+
+  span {
+    color: #ff0000;
+  }
+`;
+
+const SInput = styled.input`
+  width: 642px;
+  height: 42px;
+  background-color: #3f424e;
+  border: none;
+  border-radius: 6px;
+  color: #ffffff;
+  padding: 5px;
+  margin-bottom: 15px;
+  margin-right: 20px;
+
+  &::placeholder {
+    color: #ffffff;
+    font-size: 14px;
+    font-weight: 400;
+    padding: 5px;
+  }
+`;
+
+const CheckBtn = styled.button`
+  width: 180px;
+  height: 42px;
+  border: none;
+  border-radius: 5px;
+  background-color: #5263ff;
+  color: #ffffff;
+  margin-left: 20px;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 29px;
+`;
+
+const Input = styled.input`
+  width: 866px;
+  height: 42px;
+  background-color: #3f424e;
+  border: none;
+  border-radius: 6px;
+  color: #ffffff;
+  padding: 5px;
+  margin-bottom: 15px;
+
+  &::placeholder {
+    color: #ffffff;
+    font-size: 14px;
+    font-weight: 400;
+    padding: 5px;
+  }
+`;
+
+const Text = styled.div`
+  color: #939393;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 29px;
+  margin-bottom: 15px;
+`;
+
+const Button = styled.button`
+  width: 866px;
+  height: 47px;
+  border: none;
+  border-radius: 6px;
+  background-color: #5263ff;
+  color: #ffffff;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 29px;
+  margin-top: 20px;
+  margin-bottom: 20px;
+`;

--- a/src/components/join/JoinForm.jsx
+++ b/src/components/join/JoinForm.jsx
@@ -3,9 +3,14 @@ import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import EmailCheck from "./EmailCheck";
 import NicknameCheck from "./NicknameCheck";
+import useModal from "../../hooks/useModal";
 
 export default function JoinForm() {
   const navigate = useNavigate();
+  const { openModal, Modal, closeModal } = useModal();
+
+  const [email, setEmail] = useState("");
+  const [nickname, setNickname] = useState("");
 
   // 비밀번호 확인
   const [password, setPassword] = useState("");
@@ -13,6 +18,8 @@ export default function JoinForm() {
   const [isValid, setIsValid] = useState(true); // 비밀번호 유효성 검사
   const [isError, setIsError] = useState(false); // 비밀번호 확인 후 안내 message
   const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d|[\W_]).{8,13}$/;
+
+  const isAnyFieldEmpty = !email || !password || !passwordConfirm || !nickname;
 
   const handleCheckPassword = () => {
     const isPasswordValid = passwordRegex.test(password);
@@ -27,9 +34,17 @@ export default function JoinForm() {
     }
   };
 
+  const handleJoinBtn = () => {
+    if (isAnyFieldEmpty) {
+      openModal();
+    } else {
+      navigate("/joinend");
+    }
+  };
+
   return (
     <Wrapper>
-      <EmailCheck />
+      <EmailCheck email={email} setEmail={setEmail} />
 
       <Container>
         <Label>
@@ -60,9 +75,18 @@ export default function JoinForm() {
         )}
       </Container>
 
-      <NicknameCheck />
+      <NicknameCheck nickname={nickname} setNickname={setNickname} />
 
-      <Button onClick={() => navigate("/joinend")}>가입완료</Button>
+      <Button onClick={handleJoinBtn}>가입완료</Button>
+
+      <Modal style={{ width: "400px", height: "220px" }}>
+        <ModalContent>
+          <div>
+            <ModalBody>모두 입력하지 않았습니다.</ModalBody>
+          </div>
+          <ModalButton onClick={closeModal}>확인</ModalButton>
+        </ModalContent>
+      </Modal>
     </Wrapper>
   );
 }
@@ -132,4 +156,33 @@ const Button = styled.button`
   line-height: 29px;
   margin-top: 20px;
   margin-bottom: 20px;
+`;
+
+const ModalContent = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  margin-top: 60px;
+  font-size: 14px;
+  text-align: center;
+`;
+
+const ModalBody = styled.div`
+  margin-bottom: 20px;
+  color: #c7c7c7;
+  text-align: center;
+  margin-bottom: 30px;
+`;
+
+const ModalButton = styled.button`
+  width: 301px;
+  height: 37px;
+  background-color: #5263ff;
+  font-size: 14px;
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  margin-top: 20px;
 `;

--- a/src/components/join/NicknameCheck.jsx
+++ b/src/components/join/NicknameCheck.jsx
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import styled from "styled-components";
+import useModal from "../../hooks/useModal";
+
+export default function NicknameCheck() {
+  const { openModal, Modal, closeModal } = useModal();
+
+  // 아이디 중복 확인
+  const [nickname, setNickname] = useState("");
+  const nicknameRegex = /^[a-zA-Z0-9]{1,5}$/;
+  const [isValid, setIsValid] = useState(true); // 유효성 검사
+
+  const handleNickname = () => {
+    const checkedNickname = nicknameRegex.test(nickname); // 유효성 검사한 닉네임
+
+    setIsValid(checkedNickname);
+
+    if (!nicknameRegex.test(nickname)) {
+      // 중복 확인 관련 기능 추가 예정
+      openModal();
+    } else {
+      // 중복 확인 후 맞으면? 우선 alert 생성
+      alert("확인되었습니다.");
+    }
+  };
+
+  return (
+    <>
+      <Container>
+        <Label>
+          아이디<span>*</span>
+        </Label>
+        <div>
+          <SInput
+            placeholder="이메일을 입력해주세요."
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+          />
+          <CheckBtn onClick={handleNickname}>중복 확인</CheckBtn>
+        </div>
+        <Text
+          style={{
+            color: isValid ? "#939393" : "#ff0000",
+          }}
+        >
+          최대 5글자까지 허용 (특수문자는 사용하실 수 없습니다)
+        </Text>
+      </Container>
+
+      {/* 아이디 중복 확인 modal */}
+      <Modal style={{ width: "400px", height: "220px" }}>
+        <ModalContent>
+          <div>
+            <ModalBody>
+              닉네임이 중복됩니다. 다른 닉네임을 입력해주세요.
+            </ModalBody>
+          </div>
+          <ModalButton onClick={closeModal}>확인</ModalButton>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}
+
+const Container = styled.div`
+  margin-bottom: 30px;
+`;
+
+const Label = styled.div`
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 19.5px;
+  margin-bottom: 14px;
+
+  span {
+    color: #ff0000;
+  }
+`;
+
+const SInput = styled.input`
+  width: 642px;
+  height: 42px;
+  background-color: #3f424e;
+  border: none;
+  border-radius: 6px;
+  color: #ffffff;
+  padding: 5px;
+  margin-bottom: 15px;
+  margin-right: 20px;
+
+  &::placeholder {
+    color: #ffffff;
+    font-size: 14px;
+    font-weight: 400;
+    padding: 5px;
+  }
+`;
+
+const CheckBtn = styled.button`
+  width: 180px;
+  height: 42px;
+  border: none;
+  border-radius: 5px;
+  background-color: #5263ff;
+  color: #ffffff;
+  margin-left: 20px;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 29px;
+`;
+
+const Text = styled.div`
+  color: #939393;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 29px;
+  margin-bottom: 15px;
+`;
+
+const ModalContent = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  margin-top: 60px;
+  font-size: 14px;
+  text-align: center;
+`;
+
+const ModalBody = styled.div`
+  margin-bottom: 20px;
+  color: #c7c7c7;
+  text-align: center;
+  margin-bottom: 30px;
+`;
+
+const ModalButton = styled.button`
+  width: 301px;
+  height: 37px;
+  background-color: #5263ff;
+  font-size: 14px;
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  margin-top: 20px;
+`;

--- a/src/components/join/NicknameCheck.jsx
+++ b/src/components/join/NicknameCheck.jsx
@@ -2,11 +2,11 @@ import { useState } from "react";
 import styled from "styled-components";
 import useModal from "../../hooks/useModal";
 
-export default function NicknameCheck() {
+export default function NicknameCheck({ nickname, setNickname }) {
   const { openModal, Modal, closeModal } = useModal();
 
   // 아이디 중복 확인
-  const [nickname, setNickname] = useState("");
+  //const [nickname, setNickname] = useState("");
   const nicknameRegex = /^[a-zA-Z0-9]{1,5}$/;
   const [isValid, setIsValid] = useState(true); // 유효성 검사
 

--- a/src/pages/JoinFormP.jsx
+++ b/src/pages/JoinFormP.jsx
@@ -1,9 +1,20 @@
+import styled from "styled-components";
+import JoinTitle from "../components/join/JoinTitle";
+import JoinForm from "../components/join/JoinForm";
+
 const JoinFormP = () => {
-    return (
-        <div>
-            회원가입 폼 페이지입니다.
-        </div>
-    )
-}
+  return (
+    <Wrapper>
+      <JoinTitle section2="#5263ff" />
+
+      <JoinForm />
+    </Wrapper>
+  );
+};
 
 export default JoinFormP;
+
+const Wrapper = styled.div`
+  max-width: 900px;
+  margin: 0 auto;
+`;


### PR DESCRIPTION
## PR 타입
UI 구현

## 반영 브랜치
ui/#8 => develop

closed #8 

## 변경사항
![localhost_3000_joinform](https://github.com/QuizUpWebProject/front/assets/95006849/4f50dc0a-a3e5-455f-b821-bd4f36669545)
- 아이디 입력
   - 아이디 유효성 검사를 통과하지 않으면 안내 문구가 빨간색으로 바뀌도록 구현
   - 중복 확인 버튼 클릭 시 modal 구현 (중복 확인은 추후 기능 구현 예정) 
- 비밀번호 입력
   - 비밀번호 유효성 검사를 통과하지 않으면 안내 문구가 빨간색으로 바뀌도록 구현
- 비밀번호 재입력
   - 두 input 창의 입력값이 일치하지 않으면 아래 error message 추가되도록 구현
- 닉네임 입력
   - 닉네임 유효성 검사를 통과하지 않으면 안내 문구가 빨간색으로 바뀌도록 구현
   - 중복 확인 버튼 클릭 시 modal 구현 (중복 확인은 추후 구현 예정)
- 완료 버튼
   - 모든 input이 입력되지 않으면 modal창 구현
   - 모두 입력 후에는 `회원가입 완료` 페이지로 이동